### PR TITLE
ci: auto-assign dependabot PRs to takkyuuplayer

### DIFF
--- a/.github/workflows/after_dependabot.yml
+++ b/.github/workflows/after_dependabot.yml
@@ -1,0 +1,20 @@
+name: after-dependabot
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  gomod:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Review PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} --add-assignee takkyuuplayer


### PR DESCRIPTION
## Summary
- Dependabot が開いた PR を自動で takkyuuplayer に assign する GitHub Actions workflow を追加

## Test plan
- [ ] Dependabot による次回の PR で takkyuuplayer が自動 assign されることを確認