### PR TITLE
ci: fix after-dependabot workflow to request review

### DIFF
--- a/.github/workflows/after_dependabot.yml
+++ b/.github/workflows/after_dependabot.yml
@@ -17,4 +17,4 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh pr edit ${{ github.event.pull_request.number }} --add-assignee takkyuuplayer
+          gh pr edit ${{ github.event.pull_request.number }} --add-reviewer takkyuuplayer

--- a/.github/workflows/after_dependabot.yml
+++ b/.github/workflows/after_dependabot.yml
@@ -13,6 +13,7 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
       - name: Review PR
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- `--add-assignee` を `--add-reviewer` に変更し、Dependabot PR を assign ではなく review request する
- `gh pr edit` 実行前に `actions/checkout@v6` を実行してリポジトリを checkout

## Test plan
- [ ] Dependabot による次回の PR で takkyuuplayer が自動 reviewer に設定されることを確認