### PR TITLE
fix: test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ GOIMPORTS:=go run golang.org/x/tools/cmd/goimports@latest
 GOLANGCI_LINT:=go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 TPARAGEN:=go run github.com/sho-hata/tparagen/cmd/tparagen@latest
 
+# .env は 2 回生成する:
+#  up 前 … redis のポート変数を .env に埋めて compose の変数補間に渡すため
+#  up 後 … docker が割り当てた mysql/bigquery のホストポートを .env に反映するため
 compose/up:
 	bin/find-free-ports.sh > .env.ports
 	$(MAKE) .env
@@ -18,7 +21,7 @@ compose/up:
 
 compose/down:
 	docker compose down --remove-orphans
-	@rm .env
+	@rm -f .env .env.ports
 
 fmt:
 	$(GOIMPORTS) -w .

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ compose/up:
 
 compose/down:
 	docker compose down --remove-orphans
+	@rm .env
 
 fmt:
 	$(GOIMPORTS) -w .

--- a/test/bigquery/client_test.go
+++ b/test/bigquery/client_test.go
@@ -38,7 +38,7 @@ func TestClient(t *testing.T) {
 			dataset.Create(context.Background(), nil),
 		)
 		t.Cleanup(func() {
-			assert.NoError(t, dataset.Delete(context.Background()))
+			assert.NoError(t, dataset.DeleteWithContents(context.Background()))
 		})
 
 		// List datasets


### PR DESCRIPTION
## 概要
  - `test/bigquery`: データセット削除の後始末を `Delete` → `DeleteWithContents` に変更し、テーブルが残っている場合の削除失敗を解消
  - `Makefile` (`/simplify` 由来):
    - `compose/down` の `rm .env` を `rm -f .env .env.ports` に変更し、`.env` 不在時のエラー回避と `.env.ports` の後始末漏れを解消
    - `compose/up` が `.env` を 2 回生成する理由（up 前=redis ポート補間 / up 後=mysql・bigquery のホストポート反映）をコメントで明記

## テスト
- `make -n compose/up` / `compose/down` で構文・変数展開を確認

  🤖 Generated with [Claude Code](https://claude.com/claude-code)