### PR TITLE
fix(make): isolate compose project per git worktree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
 SHELL:=/bin/bash
+
+# compose のプロジェクト名はディレクトリの basename 由来のため、git worktree を
+# 複数切ると衝突しうる。パスのハッシュを混ぜて worktree ごとに一意にする。
+COMPOSE_PROJECT_NAME:=$(shell basename '$(CURDIR)' | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g')-$(shell printf %s '$(CURDIR)' | shasum | cut -c1-8)
+export COMPOSE_PROJECT_NAME
+
 GOIMPORTS:=go run golang.org/x/tools/cmd/goimports@latest
 GOLANGCI_LINT:=go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 TPARAGEN:=go run github.com/sho-hata/tparagen/cmd/tparagen@latest


### PR DESCRIPTION
## 問題

Docker Compose のプロジェクト名はデフォルトでディレクトリの basename から決まるため、git worktree を複数切って `make compose/up` すると、basename が衝突した場合にコンテナを共有してしまう。その結果、片方の worktree での `make compose/down` がもう片方の環境まで破壊してしまう。

## 修正

`COMPOSE_PROJECT_NAME` を「ディレクトリの basename + 作業ディレクトリパスの SHA-1 ハッシュ先頭 8 文字」(例: `go-exercise-eba5fe76`)から導出して Makefile で export するようにした。これで worktree ごとに compose プロジェクトが完全に分離される。

ホスト側ポートは既に `bin/find-free-ports.sh` でランダム化され `.env` も worktree ごとに生成されるため、この変更だけで複数 worktree の並行稼働が成立する。`/etc/hosts` の redis-cluster エントリは 127.0.0.1 への固定マッピングでポートが worktree ごとに異なるため、共有のままで問題ない。

## 確認

- make 経由で `COMPOSE_PROJECT_NAME` が一意な名前に解決されること
- `docker compose config` がその名前をプロジェクト名として採用すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
