### PR TITLE
chore(makefile): remove unused update target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,12 +32,6 @@ golangci-lint:
 tparagen:
 	$(TPARAGEN)
 
-update:
-	go mod edit -go=$(shell go env GOVERSION | sed 's/^go//' | sed -e 's/.[0-9]$+$$//g')
-	go get -u
-	go mod tidy
-	go mod download
-
 load/etc/hosts/redis-cluster:
 	@echo "127.0.0.1 redis-cluster-node-1 redis-cluster-node-2 redis-cluster-node-3" | sudo tee -a /etc/hosts
 


### PR DESCRIPTION
## Summary

- Makefile から使われなくなった `update` ターゲット（`go mod edit` / `go get -u` / `go mod tidy` / `go mod download`）を削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)
